### PR TITLE
Remove call of hold(true) since this is the default behaviour

### DIFF
--- a/openensembles/openensembles.py
+++ b/openensembles/openensembles.py
@@ -185,8 +185,6 @@ class data:
 				ax.set_zlabel(self.x[source_name][2])
 
 		else:
-			plt.hold(True)
-			ax.hold(True)
 			for clusterNum in clusters:
 				indexes = np.where(class_labels==clusterNum)
 				plt.plot(self.x[source_name], self.D[source_name][indexes].transpose(), c=next(color))


### PR DESCRIPTION
Remove call of hold(true) since this is the default behaviour and deprecated (removed) on the latest versions of matplotlib (https://github.com/matplotlib/matplotlib/issues/12337/)

This PR fixes: https://github.com/NaegleLab/OpenEnsembles/issues/8